### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proxy-generator.yml
+++ b/.github/workflows/proxy-generator.yml
@@ -1,5 +1,8 @@
 name: Proxy Generator
 
+permissions:
+  contents: write
+
 on:
   schedule:
     # Run every hour at minute 0


### PR DESCRIPTION
Potential fix for [https://github.com/Kouni/ProxyGenerator/security/code-scanning/1](https://github.com/Kouni/ProxyGenerator/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves reading repository contents and pushing changes, we will set `contents: write` permissions at the workflow level. This ensures that the `GITHUB_TOKEN` has only the necessary permissions.

The `permissions` block will be added at the root level of the workflow file, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
